### PR TITLE
insertIntoTable updated for columns and values, tests updated

### DIFF
--- a/models/State.js
+++ b/models/State.js
@@ -8,9 +8,6 @@ class State {
     }
 
     createTable(command) {
-        if (command.name !== 'CREATE TABLE') {
-            return 'Wrong command type'
-        }
         const newTable = {
             name: command.tableName,
             columns: command.columns,
@@ -20,9 +17,6 @@ class State {
     }
 
     insertIntoTable(command) {
-        if (command.name !== 'INSERT INTO') {
-            return 'Wrong command type'
-        }
         const tableIndex = this.tablelist.findIndex(
             (element) => element.name === command.tableName
         )
@@ -40,9 +34,6 @@ class State {
     }
 
     selectAllFromTable(command) {
-        if (command.name !== 'SELECT *') {
-            return 'Wrong command type'
-        }
         const tableIndex = this.tablelist.findIndex(
             (table) => table.name === command.tableName
         )

--- a/models/State.js
+++ b/models/State.js
@@ -11,12 +11,12 @@ class State {
         if (command.name !== 'CREATE TABLE') {
             return 'Wrong command type'
         }
-        const newObject = {
+        const newTable = {
             name: command.tableName,
             columns: command.columns,
             rows: [],
         }
-        this.tablelist.push(newObject)
+        this.tablelist.push(newTable)
     }
 
     insertIntoTable(command) {
@@ -27,15 +27,15 @@ class State {
             (element) => element.name === command.tableName
         )
         let newtablelist = [...this.tablelist]
-        const newRowObject = {
+        const newRow = {
             id: newtablelist[tableIndex].rows.length + 1,
         }
         for (let i = 0; i < command.columns.length; i++) {
             const column = command.columns[i]
             const value = command.values[i]
-            newRowObject[column] = value
+            newRow[column] = value
         }
-        newtablelist[tableIndex].rows.push(newRowObject)
+        newtablelist[tableIndex].rows.push(newRow)
         this.tablelist = newtablelist
     }
 
@@ -44,7 +44,7 @@ class State {
             return 'Wrong command type'
         }
         const tableIndex = this.tablelist.findIndex(
-            (element) => element.name === command.tableName
+            (table) => table.name === command.tableName
         )
         return this.tablelist[tableIndex].rows
     }

--- a/models/State.js
+++ b/models/State.js
@@ -27,9 +27,13 @@ class State {
             (element) => element.name === command.tableName
         )
         let newtablelist = [...this.tablelist]
-        //TODO update wanted columns
         const newRowObject = {
             id: newtablelist[tableIndex].rows.length + 1,
+        }
+        for (let i = 0; i < command.columns.length; i++) {
+            const column = command.columns[i]
+            const value = command.values[i]
+            newRowObject[column] = value
         }
         newtablelist[tableIndex].rows.push(newRowObject)
         this.tablelist = newtablelist

--- a/tests/State.test.js
+++ b/tests/State.test.js
@@ -38,10 +38,14 @@ test('INSERT INTO creates row and updates id', () => {
     const insertCommand = {
         name: 'INSERT INTO',
         tableName: 'Tuotteet',
+        columns: ['nimi', 'hinta'],
+        values: ['tuote', 10],
     }
     state.insertIntoTable(insertCommand)
     const rows = state.tables[0].rows
     expect(rows[0].id).toBe(1)
+    expect(rows[0].nimi).toBe('tuote')
+    expect(rows[0].hinta).toBe(10)
 })
 
 test('SELECT * FROM returns rows from table', () => {
@@ -63,6 +67,8 @@ test('SELECT * FROM returns rows from table', () => {
     const insertCommand = {
         name: 'INSERT INTO',
         tableName: 'Tuotteet',
+        columns: ['nimi', 'hinta'],
+        values: ['tuote', 10],
     }
     state.insertIntoTable(insertCommand)
     const selectCommand = {


### PR DESCRIPTION
insertIntoTable-toiminnallisuus päivitetty vastaamaan komennon rakennetta. Kannattaako [komennon nimen validointia](https://github.com/hy-sql/hy-sql-backend/blob/stateobjectclass/models/State.js#L11) tehdä enää tällä abstraktiotasolla jos meillä on komentoskeemat olemassa? Voin poistaa nuo rivit ennen mergeä jos ovat turhia. Muuten luokka mielestäni valmis execute-komentoihin liitettäväksi