### PR TITLE
Updated execute methods return values in commands and tests to match

### DIFF
--- a/commands/createTableCommand.js
+++ b/commands/createTableCommand.js
@@ -8,9 +8,7 @@ const isCommand = (fullCommandAsStringList) =>
 const execute = (fullCommandAsStringList) => {
     const parsedCommand = parseCommand(fullCommandAsStringList)
 
-    const result = CreateTableSchema.validate(parsedCommand)
-
-    return !result.error ? parsedCommand : result.error
+    return CreateTableSchema.validate(parsedCommand)
 }
 
 const parseCommand = (fullCommandAsStringList) => {

--- a/commands/insertIntoCommand.js
+++ b/commands/insertIntoCommand.js
@@ -7,9 +7,8 @@ const isCommand = (fullCommandAsStringList) =>
 const execute = (fullCommandAsStringList) => {
     const parsedCommand = parseCommand(fullCommandAsStringList)
     if (parsedCommand.error) return parsedCommand.error
-    const result = InsertIntoSchema.validate(parsedCommand)
 
-    return !result.error ? parsedCommand : result.error
+    return InsertIntoSchema.validate(parsedCommand)
 }
 
 const parseCommand = (fullCommandAsStringList) => {

--- a/commands/selectAllCommand.js
+++ b/commands/selectAllCommand.js
@@ -6,9 +6,7 @@ const isCommand = (fullCommandAsStringList) =>
 const execute = (fullCommandAsStringList) => {
     const parsedCommand = parseCommand(fullCommandAsStringList)
 
-    const validationResult = selectAllSchema.validate(parsedCommand)
-
-    return validationResult.error ? validationResult.error : parsedCommand
+    return selectAllSchema.validate(parsedCommand)
 }
 
 const parseCommand = (fullCommandAsStringList) => {

--- a/tests/selectAllCommand.test.js
+++ b/tests/selectAllCommand.test.js
@@ -42,12 +42,16 @@ describe.each([
         })
 
         test('execute returns command object successfully', () => {
-            expect(selectAllCommand.execute(command)).toHaveProperty('name')
-            expect(selectAllCommand.execute(command)).toHaveProperty('from')
-            expect(selectAllCommand.execute(command)).toHaveProperty(
+            expect(selectAllCommand.execute(command).value).toHaveProperty(
+                'name'
+            )
+            expect(selectAllCommand.execute(command).value).toHaveProperty(
+                'from'
+            )
+            expect(selectAllCommand.execute(command).value).toHaveProperty(
                 'tableName'
             )
-            expect(selectAllCommand.execute(command)).toHaveProperty(
+            expect(selectAllCommand.execute(command).value).toHaveProperty(
                 'finalSemicolon'
             )
         })


### PR DESCRIPTION
Execute palauttaa nyt objektin, jossa komento avaimella value ja jos validoinnissa löytyi virheitä niitä vastaava objekti avaimella error. Lisäksi selectAllCommand-testien päivitys, uuden palautusarvon mukaiseksi.