### PR TITLE
test refactor: removed an unnecessary old test

### DIFF
--- a/tests/selectAllCommand.test.js
+++ b/tests/selectAllCommand.test.js
@@ -80,14 +80,5 @@ describe.each([
         test('fails validation after parsed to command object', () => {
             expect(selectAllSchema.validate(parsedCommand).error).toBeDefined()
         })
-
-        test('execute does not return command object', () => {
-            expect(selectAllCommand.execute(command)).not.toHaveProperty(
-                'tableName'
-            )
-            expect(selectAllCommand.execute(command)).not.toHaveProperty(
-                'finalSemicolon'
-            )
-        })
     })
 })


### PR DESCRIPTION
Poistin aiempien execute muutosten jälkeen vahingossa jääneen muutoksessa tarpeettomaksi muuttuneen testin SelectAllCommandin testeistä.