### PR TITLE
State fix

### DIFF
--- a/middleware/executer.js
+++ b/middleware/executer.js
@@ -28,11 +28,11 @@ const executer = (request, response, next) => {
                 )
                 noErrors = false
             } else {
-                /* state voisi palauttaa udateState metodista esim. create table ja insert intolla
-                'x - query was executed successfully'
-                tai tarkemman onnistumisviestin kuten 'Table x created successfully'
-                ja selectillä palauttaakin jo tulostaulut, jolloin tämä palautus tallennettaisiin resultArrayhin.
-                Olisi informatiivisemmat onnistumisviestit/tulostaulut.
+                /* State palauttaa updateState:sta tuloksen muodossa { result: result }
+                tai vastaavasti virheilmoituksen muodossa { error: error }. Lisäksi SELECT *
+                palauttaa taulun rivit muodossa { result: result, rows: [] }.
+                Jos CREATE TABLE -lauseessa yritetään muodostaa duplikaattisarakkeita palautetaan lista
+                virheviestejä muodossa { error: [] }
                 */
                 resultArray.push(state.updateState(command.value))
             }

--- a/middleware/executer.js
+++ b/middleware/executer.js
@@ -34,10 +34,7 @@ const executer = (request, response, next) => {
                 ja selectillä palauttaakin jo tulostaulut, jolloin tämä palautus tallennettaisiin resultArrayhin.
                 Olisi informatiivisemmat onnistumisviestit/tulostaulut.
                 */
-                state.updateState(command.value)
-                resultArray.push(
-                    `${command.value.name} -query was executed successfully`
-                )
+                resultArray.push(state.updateState(command.value))
             }
         }
     }

--- a/models/State.js
+++ b/models/State.js
@@ -21,26 +21,32 @@ class State {
     }
 
     createTable(command) {
-        let error
+        let error = this.checkCreateTableErrors(command)
+        if (error) return { error: error }
+
         const newTable = {
             name: command.tableName,
             columns: command.columns,
             rows: [],
         }
         this.tablelist.push(newTable)
-        if (!error) {
-            return {
-                result: `Table ${newTable.name} created successfully`,
-            }
-        } else {
-            return {
-                error: error,
-            }
-        }
+
+        return { result: `Table ${newTable.name} created successfully` }
+    }
+
+    checkCreateTableErrors(command) {
+        const tableIndex = this.tablelist.findIndex(
+            (e) => e.name === command.tableName
+        )
+        console.log(`TABLE INDEX ${tableIndex}`)
+        if (tableIndex !== -1)
+            return `Table ${command.tableName} already exists`
     }
 
     insertIntoTable(command) {
-        let error
+        const error = this.checkIfTableExists(command)
+        if (error) return { error: error }
+
         const tableIndex = this.tablelist.findIndex(
             (element) => element.name === command.tableName
         )
@@ -55,16 +61,22 @@ class State {
         }
         newtablelist[tableIndex].rows.push(newRow)
         this.tablelist = newtablelist
-        if (!error) {
-            return {
-                result: `INSERT INTO ${command.tableName} -query was executed succesfully`,
-            }
-        } else {
-            return { error: error }
+        return {
+            result: `INSERT INTO ${command.tableName} -query was executed succesfully`,
         }
     }
 
+    checkIfTableExists(command) {
+        const tableIndex = this.tablelist.findIndex(
+            (e) => e.name === command.tableName
+        )
+        if (tableIndex === -1) return `No such table ${command.tableName}`
+    }
+
     selectAllFromTable(command) {
+        const error = this.checkIfTableExists(command)
+        if (error) return { error: error }
+
         const tableIndex = this.tablelist.findIndex(
             (table) => table.name === command.tableName
         )

--- a/models/State.js
+++ b/models/State.js
@@ -10,30 +10,37 @@ class State {
     updateState(parsedCommand) {
         switch (parsedCommand.name) {
             case 'CREATE TABLE':
-                this.createTable(parsedCommand)
-                break
+                return this.createTable(parsedCommand)
             case 'INSERT INTO':
-                this.insertIntoTable(parsedCommand)
-                break
+                return this.insertIntoTable(parsedCommand)
             case 'SELECT *':
-                this.selectAllFromTable(parsedCommand)
-                break
+                return this.selectAllFromTable(parsedCommand)
             default:
-                console.log('sth went wrong')
                 break
         }
     }
 
     createTable(command) {
+        let error
         const newTable = {
             name: command.tableName,
             columns: command.columns,
             rows: [],
         }
         this.tablelist.push(newTable)
+        if (!error) {
+            return {
+                result: `Table ${newTable.name} created successfully`,
+            }
+        } else {
+            return {
+                error: error,
+            }
+        }
     }
 
     insertIntoTable(command) {
+        let error
         const tableIndex = this.tablelist.findIndex(
             (element) => element.name === command.tableName
         )
@@ -42,19 +49,29 @@ class State {
             id: newtablelist[tableIndex].rows.length + 1,
         }
         for (let i = 0; i < command.columns.length; i++) {
-            const column = command.columns[i]
-            const value = command.values[i]
+            const column = command.columns[i].name
+            const value = command.values[i].value
             newRow[column] = value
         }
         newtablelist[tableIndex].rows.push(newRow)
         this.tablelist = newtablelist
+        if (!error) {
+            return {
+                result: `INSERT INTO ${command.tableName} -query was executed succesfully`,
+            }
+        } else {
+            return { error: error }
+        }
     }
 
     selectAllFromTable(command) {
         const tableIndex = this.tablelist.findIndex(
             (table) => table.name === command.tableName
         )
-        return this.tablelist[tableIndex].rows
+        return {
+            result: `SELECT * FROM ${command.tableName} -query was executed succesfully`,
+            rows: this.tablelist[tableIndex].rows,
+        }
     }
 }
 

--- a/models/State.js
+++ b/models/State.js
@@ -38,9 +38,14 @@ class State {
         const tableIndex = this.tablelist.findIndex(
             (e) => e.name === command.tableName
         )
-        console.log(`TABLE INDEX ${tableIndex}`)
+
         if (tableIndex !== -1)
             return `Table ${command.tableName} already exists`
+
+        const nameArray = command.columns.map((e) => e.name)
+        const duplicates = findDuplicates(nameArray)
+        if (duplicates.length !== 0)
+            return duplicates.map((e) => `duplicate column ${e}: ${e}`)
     }
 
     insertIntoTable(command) {
@@ -86,5 +91,8 @@ class State {
         }
     }
 }
+
+const findDuplicates = (arr) =>
+    arr.filter((item, index) => arr.indexOf(item) !== index)
 
 module.exports = State

--- a/requests/postQuery.rest
+++ b/requests/postQuery.rest
@@ -59,6 +59,18 @@ Content-Type: application/json
   ]
 }
 
+### Invalid CREATE TABLE -query (duplicate columns)
+
+POST http://localhost:3001/api/query
+Content-Type: application/json
+
+{
+  "commandArray": ["CREATE TABLE Tuotteet (id INTEGER PRIMARY KEY, nimi TEXT, nimi INTEGER, id TEXT);",
+    "INSERT INTO Tuotteet (nimi, hinta) VALUES ('retiisi', 7);",
+    "SELECT * FROM Tuotteet;"
+  ]
+}
+
 ### Invalid SELECT * -query
 
 POST http://localhost:3001/api/query

--- a/requests/postQuery.rest
+++ b/requests/postQuery.rest
@@ -10,6 +10,19 @@ Content-Type: application/json
   ]
 }
 
+### Valid query for inserting several rows
+
+POST http://localhost:3001/api/query
+Content-Type: application/json
+
+{
+  "commandArray": ["CREATE TABLE Tuotteet (id INTEGER PRIMARY KEY, nimi TEXT, hinta INTEGER);",
+    "INSERT INTO Tuotteet (nimi, hinta) VALUES ('retiisi', 7);",
+    "INSERT INTO Tuotteet (nimi, hinta) VALUES ('omena', 5);",
+    "SELECT * FROM Tuotteet;"
+  ]
+}
+
 ### Valid queries demonstrating keyword case-insensitive
 
 POST http://localhost:3001/api/query

--- a/tests/State.test.js
+++ b/tests/State.test.js
@@ -38,8 +38,26 @@ test('INSERT INTO creates row and updates id', () => {
     const insertCommand = {
         name: 'INSERT INTO',
         tableName: 'Tuotteet',
-        columns: ['nimi', 'hinta'],
-        values: ['tuote', 10],
+        columns: [
+            {
+                name: 'nimi',
+            },
+            {
+                name: 'hinta',
+            },
+        ],
+        values: [
+            {
+                column: 'nimi',
+                value: 'tuote',
+                type: 'TEXT',
+            },
+            {
+                column: 'hinta',
+                value: 10,
+                type: 'INTEGER',
+            },
+        ],
     }
     state.insertIntoTable(insertCommand)
     const rows = state.tables[0].rows
@@ -75,6 +93,6 @@ test('SELECT * FROM returns rows from table', () => {
         name: 'SELECT *',
         tableName: 'Tuotteet',
     }
-    const rows = state.selectAllFromTable(selectCommand)
-    expect(rows.length).toBe(1)
+    const result = state.selectAllFromTable(selectCommand)
+    expect(result.rows.length).toBe(1)
 })

--- a/tests/State.test.js
+++ b/tests/State.test.js
@@ -44,6 +44,26 @@ test('CREATE TABLE returns error when table already exists', () => {
     expect(result.error).toBe('Table Tuotteet already exists')
 })
 
+test('CREATE TABLE returns error when trying to create duplicate columns', () => {
+    const initTables = []
+    const state = new State(initTables)
+    const command = {
+        name: 'CREATE TABLE',
+        tableName: 'Tuotteet',
+        openingBracket: '(',
+        columns: [
+            { name: 'id', type: 'INTEGER', primaryKey: true },
+            { name: 'nimi', type: 'TEXT', primaryKey: false },
+            { name: 'nimi', type: 'INTEGER', primaryKey: false },
+        ],
+        closingBracket: ')',
+        finalSemicolon: ';',
+    }
+    const result = state.createTable(command)
+    expect(result.error.length).toBe(1)
+    expect(result.error[0]).toBe('duplicate column nimi: nimi')
+})
+
 test('INSERT INTO returns error if table does not exist', () => {
     const initTables = []
     const state = new State(initTables)

--- a/tests/State.test.js
+++ b/tests/State.test.js
@@ -19,6 +19,73 @@ test('CREATE TABLE creates new table to list', () => {
     expect(state.tables[0].name).toBe('Tuotteet')
 })
 
+test('CREATE TABLE returns error when table already exists', () => {
+    const initTables = [
+        {
+            name: 'Tuotteet',
+            columns: [],
+            rows: [],
+        },
+    ]
+    const state = new State(initTables)
+    const command = {
+        name: 'CREATE TABLE',
+        tableName: 'Tuotteet',
+        openingBracket: '(',
+        columns: [
+            { name: 'id', type: 'INTEGER', primaryKey: true },
+            { name: 'nimi', type: 'TEXT', primaryKey: false },
+            { name: 'hinta', type: 'INTEGER', primaryKey: false },
+        ],
+        closingBracket: ')',
+        finalSemicolon: ';',
+    }
+    const result = state.createTable(command)
+    expect(result.error).toBe('Table Tuotteet already exists')
+})
+
+test('INSERT INTO returns error if table does not exist', () => {
+    const initTables = []
+    const state = new State(initTables)
+    const insertCommand = {
+        name: 'INSERT INTO',
+        tableName: 'Tuotteet',
+        columns: [
+            {
+                name: 'nimi',
+            },
+            {
+                name: 'hinta',
+            },
+        ],
+        values: [
+            {
+                column: 'nimi',
+                value: 'tuote',
+                type: 'TEXT',
+            },
+            {
+                column: 'hinta',
+                value: 10,
+                type: 'INTEGER',
+            },
+        ],
+    }
+    const result = state.insertIntoTable(insertCommand)
+    expect(result.error).toBe('No such table Tuotteet')
+})
+
+test('SELECT * FROM table that does not exist returns error', () => {
+    const initTables = []
+    const state = new State(initTables)
+    const selectCommand = {
+        name: 'SELECT *',
+        tableName: 'Tuotteet',
+    }
+    const result = state.selectAllFromTable(selectCommand)
+    expect(result.error).toBe('No such table Tuotteet')
+})
+
 test('INSERT INTO creates row and updates id', () => {
     const initArray = []
     const state = new State(initArray)


### PR DESCRIPTION
# Muutoksia Stateen
- Taskit 10-16 backlogilta 
- updateState palauttaa komennon tuloksen muodossa `{ result: 'Command x executed succesfully' }` tai vastaavasti virheviestin muodossa `{ error: 'virheviesti tapahtuneesta' }`
- `SELECT *` palauttaa `{ result: result, rows: [ ] }` eli objektissa nyt myös pyydetyn taulun kaikki rivit
- Virheviestit seuraavissa tapauksissa:
    - Yritetään luoda duplikaattitaulu
    - Yritetään luoda tauluun duplikaattisarakkeet
    - `INSERT INTO` tai `SELECT *` taulusta jota ei ole olemassa
- Lisäksi testicaseja ja pari uutta post querya manuaaliseen testailuun
- `executer.js` päivitetty