### PR TITLE
Fixed SELECT * parsing/validation shortcomings and some typos

### DIFF
--- a/commands/selectAllCommand.js
+++ b/commands/selectAllCommand.js
@@ -5,7 +5,10 @@ const parseCommand = (fullCommandAsStringList) => {
         name: fullCommandAsStringList.slice(0, 2).join(' '),
         from: fullCommandAsStringList[2],
         tableName: fullCommandAsStringList[3],
-        finalSemicolon: fullCommandAsStringList[4],
+        finalSemicolon:
+            fullCommandAsStringList[fullCommandAsStringList.length - 1] === ';'
+                ? ';'
+                : undefined,
     }
 
     return selectAllSchema.validate(parsedCommand)

--- a/models/SelectAllSchema.js
+++ b/models/SelectAllSchema.js
@@ -6,16 +6,29 @@ const SelectAllSchema = Joi.object({
         'any.required': 'Query must begin with SELECT *',
     }),
 
-    from: Joi.string().required().valid('FROM').insensitive().messages({
-        'any.only': 'SELECT * must be followed by FROM',
-        'any.required': 'SELECT * must be followed by FROM',
-    }),
+    from: Joi.string()
+        .required()
+        .pattern(/;/, { invert: true })
+        .pattern(/^[F,f][R,r][O,o][M,m]$/)
+        .messages({
+            'string.pattern.invert.base':
+                'Semicolon should only be found at the end of a query',
+            'string.pattern.base': 'SELECT * must be followed by FROM',
+            'any.required': 'SELECT * must be followed by FROM',
+        }),
 
-    tableName: Joi.string().required().pattern(/^\w+$/).max(64).messages({
-        'any.required': 'Query must contain a table name',
-        'string.pattern.base':
-            'Table name should only contain one or more alphanumeric characters and underscores',
-    }),
+    tableName: Joi.string()
+        .required()
+        .pattern(/;/, { invert: true })
+        .pattern(/^\w+$/)
+        .max(64)
+        .messages({
+            'string.pattern.invert.base':
+                'Semicolon should only be found at the end of a query',
+            'any.required': 'Query must contain a table name',
+            'string.pattern.base':
+                'Table name should only contain one or more alphanumeric characters and underscores',
+        }),
 
     finalSemicolon: Joi.string().required().valid(';').messages({
         'any.only': 'Query must end with ;',

--- a/requests/postQuery_heroku.rest
+++ b/requests/postQuery_heroku.rest
@@ -10,7 +10,7 @@ Content-Type: application/json
   ]
 }
 
-### Valid queries demonstrating keyword case-insensitive
+### Valid queries demonstrating keyword case-insensitivity
 
 POST https://hy-sql.herokuapp.com/api/query
 Content-Type: application/json

--- a/tests/selectAllCommand.test.js
+++ b/tests/selectAllCommand.test.js
@@ -10,7 +10,7 @@ describe.each(['SELEC * FROM Taulu;', 'SELECT a FROM Taulu;'])(
                 .replace(/\s\s+/g, ' ')
                 .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
 
-            test('is not reconised as SELECT * -command', () => {
+            test('is not recognised as a command', () => {
                 expect(commands.isCommand(command)).toBeFalsy()
             })
         })
@@ -29,7 +29,7 @@ describe.each([
             .replace(/\s\s+/g, ' ')
             .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
 
-        test('is recognised as SELECT * -command', () => {
+        test('is recognised as a command', () => {
             expect(commands.isCommand(command)).toBeTruthy()
         })
 
@@ -60,7 +60,7 @@ describe.each([
             .replace(/\s\s+/g, ' ')
             .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
 
-        test('is recognised as SELECT * -command', () => {
+        test('is recognised as a command', () => {
             expect(commands.isCommand(command)).toBeTruthy()
         })
 


### PR DESCRIPTION
Validaatio tunnistaa nyt virheellisinä muualle kuin loppuun sijoitetut  puolipisteet ja antaa niistä erillisen virheviestin. Tunnistaa nyt myös virheellisenä kyselyn, jossa jotain lopun puolipisteen jälkeen. Annetut virheviestit viittaavat nyt (ainakin kaikissa keksimissäni syötteissä) oikeisiin asioihin. Lisäksi muutama typo korjaus ja testin kuvauksen päivitys.