### PR TITLE
Another select * fix

### DIFF
--- a/commands/selectAllCommand.js
+++ b/commands/selectAllCommand.js
@@ -11,7 +11,25 @@ const parseCommand = (fullCommandAsStringList) => {
                 : undefined,
     }
 
-    return selectAllSchema.validate(parsedCommand)
+    const validationResult = selectAllSchema.validate(parsedCommand)
+
+    /* if there is something additional between the table name and ending semicolon
+        an error about the nonbelonging part is created and added to existing
+        validation errors or an error object is added into the validation object */
+    if (fullCommandAsStringList.length > 5) {
+        const additional = fullCommandAsStringList
+            .slice(4, fullCommandAsStringList.length - 1)
+            .join(' ')
+        const errorMessage = `The following part of the query is causing it to fail: '${additional}'`
+
+        validationResult.error
+            ? validationResult.error.details.push({ message: errorMessage })
+            : (validationResult.error = {
+                details: [{ message: errorMessage }],
+            })
+    }
+
+    return validationResult
 }
 
 module.exports = { parseCommand }

--- a/tests/selectAllCommand.test.js
+++ b/tests/selectAllCommand.test.js
@@ -1,21 +1,22 @@
 const selectAllCommand = require('../commands/selectAllCommand')
 const commandService = require('../services/CommandService')
 
-describe.each(['SELEC * FROM Taulu;', 'SELECT a FROM Taulu;'])(
-    'Query not beginning with SELECT *',
-    (wrongCommand) => {
-        describe(wrongCommand, () => {
-            const command = wrongCommand
-                .trim()
-                .replace(/\s\s+/g, ' ')
-                .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
+describe.each([
+    'SELEC * FROM Taulu;',
+    'SELECT a FROM Taulu;',
+    'SELECT FROM Taulu',
+])('Query not beginning with SELECT *', (wrongCommand) => {
+    describe(wrongCommand, () => {
+        const command = wrongCommand
+            .trim()
+            .replace(/\s\s+/g, ' ')
+            .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
 
-            test('is not recognised as a command', () => {
-                expect(commandService.parseCommand(command)).toBeFalsy()
-            })
+        test('does not pass validation', () => {
+            expect(selectAllCommand.parseCommand(command).error).toBeDefined()
         })
-    }
-)
+    })
+})
 
 describe.each([
     'SELECT * FROM Taulu76;',

--- a/tests/selectAllCommand.test.js
+++ b/tests/selectAllCommand.test.js
@@ -54,6 +54,7 @@ describe.each([
     'SELECT * FROM Taulu:',
     'SELECT * FROM Taulu',
     'SELECT * FROM',
+    'SELECT * FROM Taulu)a;',
 ])('Invalid SELECT * -query', (invalidCommand) => {
     describe(invalidCommand, () => {
         const command = invalidCommand

--- a/tests/selectAllCommand.test.js
+++ b/tests/selectAllCommand.test.js
@@ -4,7 +4,7 @@ const commandService = require('../services/CommandService')
 describe.each([
     'SELEC * FROM Taulu;',
     'SELECT a FROM Taulu;',
-    'SELECT FROM Taulu',
+    'SELECT FROM Taulu;',
 ])('Query not beginning with SELECT *', (wrongCommand) => {
     describe(wrongCommand, () => {
         const command = wrongCommand


### PR DESCRIPTION
SELECT * validaatio tunnistaa nyt kyselyt, joissa ylimääräistä virheelliseksi ja palauttaa näistä virheen. Eli nyt esim. "SELECT * FROM Taulu );" ei läpäise validaatiota. Lisäksi aiempien backendin muuhun rakenteeseen tehtyjen muutosten yhteydessä eräs testi oli muokattu vahingossa muotoon, joka olisi todennäköisesti tullut aiheuttamaan tulevaisuudessa ongelmia, kun mahdollsta tehdä muita SELECT kyselyitä. Nyt testi tulevaisuudessa harmiton ja testaa SELECT *-komennon toimintaa paremmin.