### PR TITLE
WhereSchema, WhereCommand ja niiden integrointi SELECT *:een

### DIFF
--- a/commands/selectAllCommand.js
+++ b/commands/selectAllCommand.js
@@ -1,11 +1,18 @@
 const {
     SelectAllSchema,
     SelectAllOrderBySchema,
+    SelectAllWhereSchema,
 } = require('../models/SelectAllSchema')
+const {
+    queryContainsWhereKeyword,
+    parseWhereToCommandObject,
+} = require('./whereCommand')
 
 const parseCommand = (fullCommandAsStringList) => {
     if (hasOrderByKeywords(fullCommandAsStringList)) {
         return parseSelectAllOrderBy(fullCommandAsStringList)
+    } else if (queryContainsWhereKeyword(fullCommandAsStringList)) {
+        return parseSelectAllWhere(fullCommandAsStringList)
     }
 
     return parseSelectAll(fullCommandAsStringList)
@@ -43,7 +50,7 @@ const parseSelectAll = (fullCommandAsStringList) => {
         const additional = fullCommandAsStringList
             .slice(4, fullCommandAsStringList.length - 1)
             .join(' ')
-        const errorMessage = `The following part of the query is causing it to fail: '${additional}'`
+        const errorMessage = `The following part of the query is probably incorrect and causing it to fail: '${additional}'`
 
         validationResult.error
             ? validationResult.error.details.push({ message: errorMessage })
@@ -70,6 +77,21 @@ const parseSelectAllOrderBy = (fullCommandAsStringList) => {
     }
 
     return SelectAllOrderBySchema.validate(parsedCommand)
+}
+
+const parseSelectAllWhere = (fullCommandAsStringList) => {
+    const parsedCommand = {
+        name: fullCommandAsStringList.slice(0, 2).join(' '),
+        from: fullCommandAsStringList[2],
+        tableName: fullCommandAsStringList[3],
+        where: parseWhereToCommandObject(fullCommandAsStringList.slice(4)),
+        finalSemicolon:
+            fullCommandAsStringList[fullCommandAsStringList.length - 1] === ';'
+                ? ';'
+                : undefined,
+    }
+
+    return SelectAllWhereSchema.validate(parsedCommand)
 }
 
 const parseOrderBy = (slicedCommandAsStringArray) => {

--- a/commands/selectAllCommand.js
+++ b/commands/selectAllCommand.js
@@ -30,8 +30,8 @@ const hasOrderByKeywords = (fullCommandAsStringList) => {
     return hasOrder > 0 && hasBy > 0 ? hasOrder < hasBy : false
 }
 
-const parseSelectAll = (fullCommandAsStringList) => {
-    const parsedCommand = {
+const parseBaseCommand = (fullCommandAsStringList) => {
+    return {
         name: fullCommandAsStringList.slice(0, 2).join(' '),
         from: fullCommandAsStringList[2],
         tableName: fullCommandAsStringList[3],
@@ -40,7 +40,10 @@ const parseSelectAll = (fullCommandAsStringList) => {
                 ? ';'
                 : undefined,
     }
+}
 
+const parseSelectAll = (fullCommandAsStringList) => {
+    const parsedCommand = parseBaseCommand(fullCommandAsStringList)
     const validationResult = SelectAllSchema.validate(parsedCommand)
 
     /* if there is something additional between the table name and ending semicolon
@@ -63,33 +66,19 @@ const parseSelectAll = (fullCommandAsStringList) => {
 }
 
 const parseSelectAllOrderBy = (fullCommandAsStringList) => {
-    const parsedCommand = {
-        name: fullCommandAsStringList.slice(0, 2).join(' '),
-        from: fullCommandAsStringList[2],
-        tableName: fullCommandAsStringList[3],
-        orderBy: parseOrderBy(
-            fullCommandAsStringList.slice(4, fullCommandAsStringList.length - 1)
-        ),
-        finalSemicolon:
-            fullCommandAsStringList[fullCommandAsStringList.length - 1] === ';'
-                ? ';'
-                : undefined,
-    }
+    const parsedCommand = parseBaseCommand(fullCommandAsStringList)
+    parsedCommand.orderBy = parseOrderBy(
+        fullCommandAsStringList.slice(4, fullCommandAsStringList.length - 1)
+    )
 
     return SelectAllOrderBySchema.validate(parsedCommand)
 }
 
 const parseSelectAllWhere = (fullCommandAsStringList) => {
-    const parsedCommand = {
-        name: fullCommandAsStringList.slice(0, 2).join(' '),
-        from: fullCommandAsStringList[2],
-        tableName: fullCommandAsStringList[3],
-        where: parseWhereToCommandObject(fullCommandAsStringList.slice(4)),
-        finalSemicolon:
-            fullCommandAsStringList[fullCommandAsStringList.length - 1] === ';'
-                ? ';'
-                : undefined,
-    }
+    const parsedCommand = parseBaseCommand(fullCommandAsStringList)
+    parsedCommand.where = parseWhereToCommandObject(
+        fullCommandAsStringList.slice(4)
+    )
 
     return SelectAllWhereSchema.validate(parsedCommand)
 }

--- a/commands/whereCommand.js
+++ b/commands/whereCommand.js
@@ -1,0 +1,51 @@
+const queryContainsWhereKeyword = (fullCommandAsStringList) => {
+    const where = fullCommandAsStringList.findIndex(
+        (string) => string.toUpperCase() === 'WHERE'
+    )
+    console.log('has where: ', where > 0)
+    return where > 0
+}
+
+/* expects as input a sliced version of the array containing the full command.
+  The slicing must be done so that the input array begins with the expected
+  location of the WHERE keyword. Method returns a command object to be validated
+  as a part of the whole query.*/
+const parseWhereToCommandObject = (slicedCommandAsStringList) => {
+    const keyword = slicedCommandAsStringList[0]
+    let columnSignValue = slicedCommandAsStringList[1]
+        ? slicedCommandAsStringList[1]
+        : ''
+
+    let sign
+    if (columnSignValue.includes('<=')) {
+        sign = '<='
+    } else if (columnSignValue.includes('>=')) {
+        sign = '>='
+    } else if (columnSignValue.includes('=')) {
+        sign = '='
+    } else if (columnSignValue.includes('<')) {
+        sign = '<'
+    } else if (columnSignValue.includes('>')) {
+        sign = '>'
+    }
+
+    const columnName = sign ? columnSignValue.split(sign)[0] : columnSignValue
+    let value = sign ? columnSignValue.split(sign)[1] : undefined
+
+    let valueType = 'INTEGER'
+    if (value) {
+        RegExp('^[0-9]+$').test(value)
+            ? (value = Number(value))
+            : (valueType = 'TEXT')
+    }
+
+    return {
+        keyword,
+        columnName,
+        sign,
+        valueType,
+        value,
+    }
+}
+
+module.exports = { queryContainsWhereKeyword, parseWhereToCommandObject }

--- a/commands/whereCommand.js
+++ b/commands/whereCommand.js
@@ -12,27 +12,49 @@ const queryContainsWhereKeyword = (fullCommandAsStringList) => {
   as a part of the whole query.*/
 const parseWhereToCommandObject = (slicedCommandAsStringList) => {
     const keyword = slicedCommandAsStringList[0]
-    let columnSignValue = slicedCommandAsStringList[1]
+    const columnSignValue = slicedCommandAsStringList[1]
         ? slicedCommandAsStringList[1]
         : ''
+    const signValueOption = slicedCommandAsStringList[2]
+        ? slicedCommandAsStringList[2]
+        : ''
+    const valueOption = slicedCommandAsStringList[3]
+        ? slicedCommandAsStringList[3]
+        : ''
 
-    let sign
-    if (columnSignValue.includes('<=')) {
-        sign = '<='
-    } else if (columnSignValue.includes('>=')) {
-        sign = '>='
-    } else if (columnSignValue.includes('=')) {
-        sign = '='
-    } else if (columnSignValue.includes('<')) {
-        sign = '<'
-    } else if (columnSignValue.includes('>')) {
-        sign = '>'
+    let columnName = undefined
+    let sign = findSign(columnSignValue)
+    let valueType = 'INTEGER'
+    let value = undefined
+
+    let signSet = false
+
+    if (!sign) {
+        columnName = columnSignValue
+        sign = findSign(signValueOption)
+
+        if (sign) {
+            sign =
+                signValueOption.slice(0, sign.length) === sign
+                    ? sign
+                    : undefined
+        }
+    } else {
+        columnName = columnSignValue.split(sign)[0]
+        value = columnSignValue.endsWith(sign)
+            ? signValueOption
+            : columnSignValue.split(sign)[1]
+        signSet = true
     }
 
-    const columnName = sign ? columnSignValue.split(sign)[0] : columnSignValue
-    let value = sign ? columnSignValue.split(sign)[1] : undefined
+    if (!sign) {
+        value = signValueOption
+    } else if (sign && !signSet) {
+        value = signValueOption.endsWith(sign)
+            ? valueOption
+            : signValueOption.split(sign)[1]
+    }
 
-    let valueType = 'INTEGER'
     if (value) {
         RegExp('^[0-9]+$').test(value)
             ? (value = Number(value))
@@ -46,6 +68,22 @@ const parseWhereToCommandObject = (slicedCommandAsStringList) => {
         valueType,
         value,
     }
+}
+
+const findSign = (string) => {
+    if (string.includes('<=')) {
+        return '<='
+    } else if (string.includes('>=')) {
+        return '>='
+    } else if (string.includes('=')) {
+        return '='
+    } else if (string.includes('<')) {
+        return '<'
+    } else if (string.includes('>')) {
+        return '>'
+    }
+
+    return undefined
 }
 
 module.exports = { queryContainsWhereKeyword, parseWhereToCommandObject }

--- a/models/SelectAllSchema.js
+++ b/models/SelectAllSchema.js
@@ -1,5 +1,6 @@
 const Joi = require('@hapi/joi')
 const OrderBySchema = require('./OrderBySchema')
+const WhereSchema = require('./WhereSchema')
 
 const SelectAllSchema = Joi.object({
     name: Joi.string().required().valid('SELECT *').insensitive().messages({
@@ -29,6 +30,7 @@ const SelectAllSchema = Joi.object({
             'any.required': 'Query must contain a table name',
             'string.pattern.base':
                 'Table name should only contain one or more alphanumeric characters and underscores',
+            'string.max': 'Table name is too long',
         }),
 
     finalSemicolon: Joi.string().required().valid(';').messages({
@@ -41,4 +43,12 @@ const SelectAllOrderBySchema = SelectAllSchema.keys({
     orderBy: OrderBySchema,
 })
 
-module.exports = { SelectAllSchema, SelectAllOrderBySchema }
+const SelectAllWhereSchema = SelectAllSchema.keys({
+    where: WhereSchema,
+})
+
+module.exports = {
+    SelectAllSchema,
+    SelectAllOrderBySchema,
+    SelectAllWhereSchema,
+}

--- a/models/WhereSchema.js
+++ b/models/WhereSchema.js
@@ -63,7 +63,7 @@ const WhereSchema = Joi.object({
                     'Semicolon should only be found at the end of a query',
                 'string.pattern.base':
                     'String values in query should be in quotes and contain only alphanumeric characters and underscores',
-                'string.max': 'Table name is too long',
+                'string.max': 'A string value is too long',
             }),
     }),
 })

--- a/models/WhereSchema.js
+++ b/models/WhereSchema.js
@@ -1,0 +1,71 @@
+const Joi = require('@hapi/joi')
+
+/* WhereSchema expects the following keyes; keyword, columnName, sign, valueType and value.
+  Of these the valueType must be added when parsing to indicate wheter the value is an integer or a string,
+  to indicate on what rules it should be validated. The valueType must be either 'TEXT' or 'INTEGER'. If value is
+  undefined valueType should default to 'INTEGER'.
+  The validation rules for a value are: an integer must be a number, a string must be surrounded by quotes and
+  only contain underscores and alphanumeric characters.
+*/
+
+const WhereSchema = Joi.object({
+    keyword: Joi.string()
+        .required()
+        .pattern(/;/, { invert: true })
+        .pattern(/^[W,w][H,h][E,e][R,r][E,e]$/)
+        .messages({
+            'any.required':
+                'This query is expected to have the following keyword: WHERE',
+            'string.pattern.invert.base':
+                'Semicolon should only be found at the end of a query',
+            'string.pattern.base':
+                'WHERE is either misspelled or in the wrong position',
+        }),
+
+    columnName: Joi.string()
+        .required()
+        .pattern(/;/, { invert: true })
+        .pattern(/^\w+$/)
+        .max(64)
+        .messages({
+            'any.required': 'WHERE must be followed by a column name',
+            'string.pattern.invert.base':
+                'Semicolon should only be found at the end of a query',
+            'string.pattern.base':
+                'Column names should only contain one or more alphanumeric characters and underscores',
+            'string.max': 'Column name is too long',
+        }),
+
+    sign: Joi.string().required().valid('=', '<=', '>=', '>', '<').messages({
+        'any.only':
+            'After WHERE, column name and the value must be separated by: =, <=, >=, > or <',
+        'any.required':
+            'After WHERE, column name and the value must be separated by: =, <=, >=, > or <',
+    }),
+
+    valueType: Joi.string().valid('INTEGER', 'TEXT').insensitive().required(),
+
+    value: Joi.alternatives().conditional('valueType', {
+        is: 'INTEGER',
+        then: Joi.number().required().messages({
+            'any.required':
+                'After WHERE, a value must be defined after the column name',
+        }),
+        otherwise: Joi.string()
+            .required()
+            .pattern(/;/, { invert: true })
+            .pattern(/^(')(\w+)(')$|^(")(\w+)(")$/)
+            .max(64)
+            .messages({
+                'any.required':
+                    'After WHERE, a value must be defined after the column name',
+                'string.pattern.invert.base':
+                    'Semicolon should only be found at the end of a query',
+                'string.pattern.base':
+                    'String values in query should be in quotes and contain only alphanumeric characters and underscores',
+                'string.max': 'Table name is too long',
+            }),
+    }),
+})
+
+module.exports = WhereSchema

--- a/requests/postQuery.rest
+++ b/requests/postQuery.rest
@@ -94,3 +94,16 @@ Content-Type: application/json
     "SELECT * FROM Tuotteet;"
   ]
 }
+
+### For testing SELECT * ... WHERE ..
+POST http://localhost:3001/api/query
+Content-Type: application/json
+
+{
+  "commandArray": ["CREATE TABLE Tuotteet (id INTEGER PRIMARY KEY, nimi TEXT, hinta INTEGER);",
+  "INSERT INTO Tuotteet (nimi, hinta) VALUES ('retiisi', 7);",
+    "SELECT * FROM Tuotteet WHERE hinta=7;",
+    "SELECT * FROM Tuotteet a WHERE nimi='retiisi';"
+  ]
+}
+

--- a/requests/postQuery_heroku.rest
+++ b/requests/postQuery_heroku.rest
@@ -69,3 +69,15 @@ Content-Type: application/json
     "SELECT * FROM Tuotteet;"
   ]
 }
+
+### For testing SELECT * ... WHERE ..
+POST https://hy-sql.herokuapp.com/api/query
+Content-Type: application/json
+
+{
+  "commandArray": ["CREATE TABLE Tuotteet (id INTEGER PRIMARY KEY, nimi TEXT, hinta INTEGER);",
+  "INSERT INTO Tuotteet (nimi, hinta) VALUES ('retiisi', 7);",
+    "SELECT * FROM Tuotteet WHERE hinta=7;",
+    "SELECT * FROM Tuotteet a WHERE nimi='retiisi';"
+  ]
+}


### PR DESCRIPTION
Luotu WhereSchema, jonka voi importata muihin Schemoihin Where osan validoimiseksi. Samalla luotu WhereCommand, jossa muihin komentoihin importattavat metodit kyselyn WHERE osan parsimiselle (toimii ainakin perustapauksissa, mutta tarkistan paremin vielä testien kirjoituksen yhteydessä) ja sen tarkistukselle löytyykö kyselyn sisätävästä taulukosta avainsana WHERE. Parsimismetodi siis palauttaa WHERE osaa vastaavan objektin, sijoitettavaksi koko kyselyn komentoobjektiin validoitavaksi sen mukana. Samalla nämä luodut WHERE validointi ja käsittely on integroitu SELECT *. Nyt siis SELECT * FROM ... WHERE ... kyselyt mahdollisia (tosin integrointi stateServiceen vielä tehtävä, että lähettää oikean tuloksen).

Kirjoitan testit heti seuraaavaksi, pahoittelut testikattavuuden laskemisesta!