### PR TITLE
very small typo fix to createTable test messages

### DIFF
--- a/tests/createTableCommand.test.js
+++ b/tests/createTableCommand.test.js
@@ -69,7 +69,7 @@ describe.each([
         .replace(/\s\s+/g, ' ')
         .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
 
-    test('valid command is recognized and true returned', () => {
+    test('invalid command is not recognized and false returned', () => {
         const result = commandService.parseCommand(fullCommandAsStringList)
 
         expect(result).toBeFalsy()


### PR DESCRIPTION
valid command is recognised and true returned
changed to
invalid command is not recognised and false returned
Just caught my eye when looking at results