### PR TITLE
seems okay

### DIFF
--- a/middleware/parser.js
+++ b/middleware/parser.js
@@ -1,5 +1,6 @@
 const commandService = require('../services/commandService')
 const CommandArraySchema = require('../models/CommandArraySchema')
+const cleanCommand = require('../utils/cleanCommand')
 
 const parser = (request, response, next) => {
     const commandArray = request.body.commandArray
@@ -18,14 +19,7 @@ const parser = (request, response, next) => {
         })
     }
 
-    const splitCommandArray = commandArray.map((input) =>
-        input
-            .trim()
-            .replace(/\s\s+/g, ' ')
-            .replace(/\s+,/g, ',')
-            .split(/[\s]|(?<=,)|(?<=\()|(?=\))|(;$)/)
-            .filter(Boolean)
-    )
+    const splitCommandArray = commandArray.map((input) => cleanCommand(input))
 
     const parsedCommands = splitCommandArray.map((c) =>
         commandService.parseCommand(c)

--- a/tests/createTableCommand.test.js
+++ b/tests/createTableCommand.test.js
@@ -1,5 +1,6 @@
 const createTableCommand = require('../commands/createTableCommand')
 const commandService = require('../services/commandService')
+const cleanCommand = require('../utils/cleanCommand')
 
 describe.each([
     'CREATE TABLE Tuotteet (id INTEGER PRIMARY KEY, nimi TEXT, hinta INTEGER);',
@@ -9,10 +10,7 @@ describe.each([
     '   create taBle    tuoTTeet (id inTEger    primary KEY, NIMI    text, hintA    inTEger);',
     'crEAte        TABLE Tuotteet (id INTEGER PRIMARY KEY, nimi TEXT, hinta INTEGER);',
 ])('valid command testing', (command) => {
-    const fullCommandAsStringList = command
-        .trim()
-        .replace(/\s\s+/g, ' ')
-        .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
+    const fullCommandAsStringList = cleanCommand(command)
 
     test('valid command is recognized and true returned', () => {
         const result = commandService.parseCommand(fullCommandAsStringList)
@@ -44,10 +42,7 @@ describe.each([
     '   create taBle    tuoTTeet ',
     '   create      ',
 ])('invalid command with the right name (CREATE TABLE) testing', (command) => {
-    const fullCommandAsStringList = command
-        .trim()
-        .replace(/\s\s+/g, ' ')
-        .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
+    const fullCommandAsStringList = cleanCommand(command)
 
     test('valid command is parsed but validation fails', () => {
         const parsedCommand = createTableCommand.parseCommand(
@@ -64,10 +59,7 @@ describe.each([
     'create taBle! tuoTTeet id inTEger primary KEY, NIMI text, hintA inTEger);',
     '   create taBle_    tuoTTeet (id     primary KEY, NIMI    text, hintA    inTEger);',
 ])('invalid command name testing', (command) => {
-    const fullCommandAsStringList = command
-        .trim()
-        .replace(/\s\s+/g, ' ')
-        .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
+    const fullCommandAsStringList = cleanCommand(command)
 
     test('invalid command is not recognized and false returned', () => {
         const result = commandService.parseCommand(fullCommandAsStringList)

--- a/tests/insertIntoCommand.test.js
+++ b/tests/insertIntoCommand.test.js
@@ -1,6 +1,7 @@
 const insertIntoCommand = require('../commands/insertIntoCommand')
 const { InsertIntoSchema } = require('../models/InsertIntoSchema')
 const commandService = require('../services/commandService')
+const cleanCommand = require('../utils/cleanCommand')
 
 describe.each([
     "INSERT INTO Tuotteet (id, nimi, hinta) VALUES (1, 'nauris', 3);",
@@ -10,10 +11,7 @@ describe.each([
     "   insert inTO    tuoTTeet (id       , NIMI, hintA) VALUES (16,     'tomaatti', 6);",
     "InSERt        INTO Tuotteet (id, nimi, hinta) VALUES (17, 'sipuli', 65);",
 ])('valid command INSERT INTO ... VALUES testing', (command) => {
-    const fullCommandAsStringList = command
-        .trim()
-        .replace(/\s\s+/g, ' ')
-        .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
+    const fullCommandAsStringList = cleanCommand(command)
 
     test('valid command is recognized and true returned', () => {
         const result = commandService.parseCommand(fullCommandAsStringList)
@@ -40,10 +38,7 @@ describe.each([
     "INSERT INTO Tuotteet (id, nimi, hinta) VALUES (13, 'kurkku', 17, 18);", //liikaa arvoja
     "INSERT INTO Tuotteet (id, nimi, hinta) VALUES (1, 'porkkana');", //liian vähän arvoja
 ])('invalid command with the right name (CREATE TABLE) testing', (command) => {
-    const fullCommandAsStringList = command
-        .trim()
-        .replace(/\s\s+/g, ' ')
-        .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
+    const fullCommandAsStringList = cleanCommand(command)
 
     test('valid command is parsed but validation fails', () => {
         const parsedCommand = insertIntoCommand.parseCommand(
@@ -62,10 +57,7 @@ describe.each([
     "INSERT INTO! Tuotteet (id, nimi, hinta) VALUES (1, 'nauris', 3);",
     "    INSERT_INTO Tuotteet (id, nimi, hinta) VALUES (1, 'nauris', 3);",
 ])('invalid command name testing', (command) => {
-    const fullCommandAsStringList = command
-        .trim()
-        .replace(/\s\s+/g, ' ')
-        .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
+    const fullCommandAsStringList = cleanCommand(command)
 
     test('invalid command is NOT recognized and false returned', () => {
         const result = commandService.parseCommand(fullCommandAsStringList)
@@ -76,10 +68,7 @@ describe.each([
 describe.each(["INSERT INTO Tuotteet (id, nimi, hinta) (1, 'nauris', 3);"])(
     'missing VALUES keyword testing',
     (command) => {
-        const fullCommandAsStringList = command
-            .trim()
-            .replace(/\s\s+/g, ' ')
-            .split(/[\s]|(?<=\()|(?=\))|(?=;)/)
+        const fullCommandAsStringList = cleanCommand(command)
 
         test('missing VALUES keyword returns an error', () => {
             const parsedCommand = insertIntoCommand.parseCommand(

--- a/utils/cleanCommand.js
+++ b/utils/cleanCommand.js
@@ -1,0 +1,10 @@
+const cleanCommand = (commandString) => {
+    return commandString
+        .trim()
+        .replace(/\s\s+/g, ' ')
+        .replace(/\s+,/g, ',')
+        .split(/[\s]|(?<=,)|(?<=\()|(?=\))|(;$)/)
+        .filter(Boolean)
+}
+
+module.exports = cleanCommand


### PR DESCRIPTION
Why?
To streamline writing tests moved the "cleaning command string" part from parser.js to it's own importable module "cleanCommand" under utils/. Now we can always use the same tricks in tests that we use in parser, and we can change behavior of both from one location. Just in case something comes up with the more complicated command structures.

What?
Made the module, integrated into createTableCommand and insertIntoCommand tests...as a test