### PR TITLE
parseTables in select no longer passes whole object

### DIFF
--- a/_requests/selectTester.rest
+++ b/_requests/selectTester.rest
@@ -7,19 +7,20 @@ Content-Type: application/json
   "commandArray": [
     "CREATE TABLE Tuotteet (id INTEGER PRIMARY KEY, nimi TEXT, hinta INTEGER);",
     "INSERT INTO Tuotteet (nimi, hinta) VALUES ('retiisi', 7);",
-    "SELECT nimi,hinta FROM Tuotteet;"
+    "INSERT INTO Tuotteet (nimi, hinta) VALUES ('lanttu', 3);",
+    "SELECT nimi,hinta FROM Tuotteet WHERE id=1;"
   ]
 }
 
 
-### puuttuu taulun nimi
+### validi select where (ehto) kysely
 
 POST http://localhost:3001/api/query
 Content-Type: application/json
 
 {
   "commandArray": [
-    "SELECT nimi,hinta FROM WHERE id=1;"
+    "SELECT nimi,hinta FROM Tuotteet WHERE id=1;"
   ]
 }
 

--- a/commands/selectCommand.js
+++ b/commands/selectCommand.js
@@ -49,8 +49,15 @@ const parseSelectColumns = (fullCommandAsStringList) => {
     }
 
     //TAULUJEN OSIO
-    parsedCommand = parseTableNames(fullCommandAsStringList, parsedCommand)
+    const { pctable, tableName } = parseTableNames(
+        fullCommandAsStringList,
+        parsedCommand.parserCounter
+    )
 
+    if (tableName) {
+        parsedCommand.parserCounter = pctable
+        parsedCommand.tableName = tableName
+    }
     // WHERE OSIO - specifies which rows to retrieve.
 
     // GROUP BY - groups rows sharing a property so that an aggregate function can be applied to each group.
@@ -83,17 +90,18 @@ const parseSelectColumns = (fullCommandAsStringList) => {
     return validationResult
 }
 
-const parseTableNames = (stringArray, parsedCommand) => {
+const parseTableNames = (stringArray, parserCounter) => {
     //näitä lisää, mieluiten johonkin ReservedWords-listaan joka importataan, *TODO: RESERVED WORDS LIST*
     if (
-        !['WHERE', 'JOIN', '(', ')', ';', 'VALUES'].includes(
-            stringArray[parsedCommand.parserCounter].toUpperCase()
+        !['WHERE', 'JOIN', '(', ')', ';', 'VALUES', 'ORDER', 'GROUP'].includes(
+            stringArray[parserCounter].toUpperCase()
         )
     ) {
-        parsedCommand.tableName = stringArray[parsedCommand.parserCounter]
-        parsedCommand.parserCounter++
+        const tableName = stringArray[parserCounter]
+        parserCounter++
+        return { pctable: parserCounter, tableName: tableName }
     }
-    return parsedCommand
+    return { pctable: parserCounter }
 }
 
 const parseSelectColumnsWhere = (fullCommandAsStringArray) => {


### PR DESCRIPTION
Cleaned that parseTables up a bit. Now it behaves better, no passing whole parsedCommand as parameter, now it takes (fullCommandAsStringList, parserCounter) and spits out (parserCounter, tableName)