### PR TITLE
Slightly cleaner parse columns for select

### DIFF
--- a/commands/insertIntoCommand.js
+++ b/commands/insertIntoCommand.js
@@ -35,7 +35,14 @@ const parseCommand = (fullCommandAsStringList) => {
         parsedCommand.parserCounter++
     }
 
-    parsedCommand = parseColumnNames(fullCommandAsStringList, parsedCommand)
+    const { pccolumns, columns } = parseColumnNames(
+        fullCommandAsStringList,
+        parsedCommand.parserCounter
+    )
+    if (columns) {
+        parsedCommand.parserCounter = pccolumns
+        parsedCommand.columns = columns
+    }
 
     if (fullCommandAsStringList[parsedCommand.parserCounter] === ')') {
         parsedCommand.columnsClosingBracket = ')'

--- a/commands/parserTools/parseColumnNames.js
+++ b/commands/parserTools/parseColumnNames.js
@@ -1,14 +1,14 @@
 const { namify, cleanStringArray } = require('./smallTools')
 
-const parseColumnNames = (stringArray, parsedCommand) => {
-    let laskuri = parsedCommand.parserCounter
-    parsedCommand.columnsOpenBrackets = 0
+const parseColumnNames = (stringArray, parserCounter) => {
+    let laskuri = parserCounter
+    let columnsOpenBrackets = 0
     const columns = []
     loop1: for (; laskuri < stringArray.length; laskuri++) {
         const element = stringArray[laskuri]
         switch (element.toUpperCase()) {
             case '(':
-                parsedCommand.columnsOpenBrackets++
+                columnsOpenBrackets++
                 continue loop1
             case ',':
                 continue loop1
@@ -23,26 +23,27 @@ const parseColumnNames = (stringArray, parsedCommand) => {
             case 'HAVING':
             case 'WHERE':
             case 'FROM':
-                if (parsedCommand.columnsOpenBrackets === 0) break loop1
+                if (columnsOpenBrackets === 0) break loop1
                 continue loop1
             case ')':
-                if (parsedCommand.columnsOpenBrackets > 0) {
-                    parsedCommand.columnsOpenBrackets--
+                if (columnsOpenBrackets > 0) {
+                    columnsOpenBrackets--
                     continue loop1
                 }
                 break loop1
             default:
-                if (parsedCommand.columnsOpenBrackets > 0) continue loop1
+                if (columnsOpenBrackets > 0) continue loop1
                 columns.push(element)
         }
     }
+
     if (laskuri !== stringArray.length) {
-        parsedCommand.parserCounter = laskuri
-        parsedCommand.columns = namify(cleanStringArray(columns))
+        return {
+            pccolumns: laskuri,
+            columns: namify(cleanStringArray(columns)),
+        }
     }
-    if (parsedCommand.columnsOpenBrackets === 0)
-        delete parsedCommand.columnsOpenBrackets
-    return parsedCommand
+    return { pccolumns: parserCounter }
 }
 
 module.exports = { parseColumnNames }

--- a/commands/selectCommand.js
+++ b/commands/selectCommand.js
@@ -36,7 +36,15 @@ const parseSelectColumns = (fullCommandAsStringList) => {
     }
 
     // SARAKKEIDEN OSIO - (*AS -- TODO*)
-    parsedCommand = parseColumnNames(fullCommandAsStringList, parsedCommand)
+    //return { pccolumns: laskuri, columns: namify(cleanStringArray(columns)) }
+    const { pccolumns, columns } = parseColumnNames(
+        fullCommandAsStringList,
+        parsedCommand.parserCounter
+    )
+    if (columns) {
+        parsedCommand.parserCounter = pccolumns
+        parsedCommand.columns = columns
+    }
 
     //FROM  (* etsiminen muualtakin -- TODO*)
     if (


### PR DESCRIPTION
Cleaned that parseColumns up a bit, no more whole object passing, takes just (stringArray, parserCounter), and gives back (parserCounter, columns). columns is an array.