### PR TITLE
LENGTH now returns error when called on nonexistent column

### DIFF
--- a/services/StateService.js
+++ b/services/StateService.js
@@ -311,7 +311,7 @@ class StateService {
     }
 
     createQueriedRows(queries, existingRows) {
-        return existingRows.reduce((rowsToReturn, row) => {
+        const createdRows = existingRows.reduce((rowsToReturn, row) => {
             const newRow = {}
 
             for (let i = 0; i < queries.length; i++) {
@@ -336,16 +336,26 @@ class StateService {
 
                     newRow[queries[i].stringValue] = expressionResult
                 } else if (queries[i].type === 'stringFunction') {
-                    newRow[queries[i].value] = executeStringFunction(
+                    const functionResult = executeStringFunction(
                         queries[i],
                         row
                     )
+
+                    functionResult.error
+                        ? (newRow.error = functionResult.error)
+                        : (newRow[queries[i].value] = functionResult)
                 }
             }
+
             rowsToReturn.push(newRow)
 
             return rowsToReturn
         }, [])
+
+        const errorRows = createdRows.filter((r) => r.error)
+        if (errorRows.length > 0) return errorRows[0]
+
+        return createdRows
     }
 
     createAggregateFunctionRow(functionField, existingRows) {

--- a/services/components/functions.js
+++ b/services/components/functions.js
@@ -1,18 +1,28 @@
 const _ = require('lodash')
 
-/* Handles string functions. Input is object containing function details and a table row.
- * Expected input format of functionDetails: { type: type, name: name, value: value, param: { paramDetails } }
+/**
+ * Handles string functions. Expected input format of functionDetails:
+ *    { type: type, name: name, value: value, param: { paramDetails } }
  *
  * Returns:
- *    - functionDetails.name === 'LENGTH': length of param.value or
- *      length of value in param.value column in input row.
+ *    - functionDetails.name === 'LENGTH': length of param.value or length of value
+ *          in param.value column in input row. If the parameter is a column that
+ *          does not exist an error object is returned.
+ * @param {Object} functionDetails object containing function details
+ * @param {Object} row table row object
  */
 const executeStringFunction = (functionDetails, row) => {
     switch (functionDetails.name) {
         case 'LENGTH':
-            return functionDetails.param.type === 'column'
-                ? row[functionDetails.param.value].toString().length
-                : functionDetails.param.value.toString().length
+            if (functionDetails.param.type === 'column') {
+                return row[functionDetails.param.value]
+                    ? row[functionDetails.param.value].toString().length
+                    : {
+                          error:
+                              'Column name given to LENGTH as parameter does not match any existing column',
+                      }
+            }
+            return functionDetails.param.value.toString().length
         case 'CONCAT':
             return 'function not implemented yet'
         case 'SUBSTRING':
@@ -20,8 +30,8 @@ const executeStringFunction = (functionDetails, row) => {
     }
 }
 
-/* Handles sql aggregate functions. Takes as input an object containing function details and the table rows.
- * Expected input format of functionDetails: { type: type, name: name, value: value, param: { paramDetails } }
+/** Handles sql aggregate functions. Expected input format of functionDetails:
+ * { type: type, name: name, value: value, param: { paramDetails } }
  *
  * Return value depends on the fields of functionDetails:
  *    - name === 'AVG': If param.value does not match any existing columns returns an error object.
@@ -35,6 +45,8 @@ const executeStringFunction = (functionDetails, row) => {
  *    - name === 'SUM': If param.value does not match any existing columns returns an error object.
  *         If it matches a column of type TEXT, 0 is returned.
  *         Otherwise sum of the values in the matched column is returned.
+ * @param {Object} functionDetails object containing function details
+ * @param {Array} rows array of table rows
  */
 const executeAggregateFunction = (functionDetails, rows) => {
     const paramValue = functionDetails.param.value

--- a/tests/integration/stateServiceSelectAdvanced.test.js
+++ b/tests/integration/stateServiceSelectAdvanced.test.js
@@ -352,6 +352,18 @@ describe('selectFrom()', () => {
         expect(result.rows).toEqual(expectedRows)
     })
 
+    test('returns expected error for LENGTH-function in select', () => {
+        const selectParser = 'SELECT LENGTH(nonexistent) FROM Tuotteet;'
+
+        const commandArray = splitCommandIntoArray(selectParser)
+        const parsedCommand = commandService.parseCommand(commandArray)
+        const result = stateService.updateState(parsedCommand.value)
+        expect(result.error).toBeDefined()
+        expect(result.error).toBe(
+            'Column name given to LENGTH as parameter does not match any existing column'
+        )
+    })
+
     test('returns row asked by MAX-function in select', () => {
         const selectParser = 'SELECT MAX(hinta) FROM Tuotteet;'
 


### PR DESCRIPTION
LENGTH- funktion kutsuminen olemassa olemattomalle sarakkeelle aiheutti TypeErrorin. Nyt LENGTH korjattu palauttamaan tällöin error-objektin. LIsäksi stateServicessa käsittely muokattu siten, että error palautuu oikeassa muodossa, että executerissa suoritus keskeytyy. Lisätty myös testi tälle tapaukselle stateService-testeihin.

Samalla functions.js kommentit muokattu JSDoc muotoon.