### PR TITLE
Select column bug fix

### DIFF
--- a/services/StateService.js
+++ b/services/StateService.js
@@ -382,7 +382,12 @@ class StateService {
 
             for (let i = 0; i < queries.length; i++) {
                 if (queries[i].type === 'column') {
-                    newRow[queries[i].value] = row[queries[i].value]
+                    const valueOfQueriedColumn = row[queries[i].value]
+                    if (valueOfQueriedColumn) {
+                        newRow[queries[i].value] = row[queries[i].value]
+                    } else {
+                        newRow.error = `no such column ${queries[i].value}`
+                    }
                 } else if (
                     queries[i].type === 'expression' &&
                     containsAggregateFunction(queries[i].value)

--- a/tests/integration/stateServiceSelectColumns.test.js
+++ b/tests/integration/stateServiceSelectColumns.test.js
@@ -44,6 +44,33 @@ describe('selectFromTable()', () => {
         expect(result.rows.length).toBe(1)
         expect(result.rows[0]['nimi']).toBe('tuote')
     })
+
+    test('returns error when queried column does not exist', () => {
+        const state = new State(new Map())
+        const stateService = new StateService(state)
+
+        const commands = [
+            'CREATE TABLE Tuotteet (id INTEGER PRIMARY KEY, nimi TEXT, hinta INTEGER);',
+            'INSERT INTO Tuotteet (nimi, hinta) VALUES (tuote, 10);',
+        ]
+
+        const splitCommandArray = commands.map((input) =>
+            splitCommandIntoArray(input)
+        )
+
+        const parsedCommands = splitCommandArray.map((c) =>
+            commandService.parseCommand(c)
+        )
+
+        parsedCommands.forEach((c) => stateService.updateState(c.value))
+
+        const selectParser = 'SELECT invalid from Tuotteet;'
+        const commandArray = splitCommandIntoArray(selectParser)
+        const parsedCommand = commandService.parseCommand(commandArray)
+        const result = stateService.selectFrom(parsedCommand.value)
+        expect(result.rows).not.toBeDefined()
+        expect(result.error).toBe('no such column invalid')
+    })
 })
 
 describe('selectFrom() with command.where', () => {


### PR DESCRIPTION
fixes issue #99 

If queried column does not exist in table SELECT now returns `{error: no such column ...}`