### PR TITLE
Limit refactor

### DIFF
--- a/commandParsers/limitParser.js
+++ b/commandParsers/limitParser.js
@@ -3,18 +3,10 @@ const { parseField } = require('./fieldParser')
 /**
  * Handles parsing of the LIMIT part of a command into an LIMIT object
  * from the given string array.
- * @param {sting[]} fullCommandAsStringArray command as string array
+ * @param {sting[]} slicedCommandAsStringArray the LIMIT part of a command as string array
  */
-const parseLimit = (fullCommandAsStringArray) => {
+const parseLimit = (slicedCommandAsStringArray) => {
     const limit = {}
-
-    const indexOfLimit = fullCommandAsStringArray.findIndex(
-        (s) => s.toUpperCase() === 'LIMIT'
-    )
-    const slicedCommandAsStringArray = fullCommandAsStringArray.slice(
-        indexOfLimit,
-        fullCommandAsStringArray.length - 1
-    )
 
     limit.keyword = slicedCommandAsStringArray[0].toUpperCase()
 

--- a/commandParsers/limitParser.js
+++ b/commandParsers/limitParser.js
@@ -1,5 +1,4 @@
 const { parseField } = require('./fieldParser')
-const { checkLimitPosition } = require('./parserTools/checkCorrectPosition')
 
 /**
  * Handles parsing of the LIMIT part of a command into an LIMIT object
@@ -8,8 +7,6 @@ const { checkLimitPosition } = require('./parserTools/checkCorrectPosition')
  */
 const parseLimit = (fullCommandAsStringArray) => {
     const limit = {}
-
-    limit.correctlyPositioned = checkLimitPosition(fullCommandAsStringArray)
 
     const indexOfLimit = fullCommandAsStringArray.findIndex(
         (s) => s.toUpperCase() === 'LIMIT'

--- a/commandParsers/selectParser.js
+++ b/commandParsers/selectParser.js
@@ -25,6 +25,7 @@ const { parseSelectFields } = require('./fieldParser')
 const { parseGroupBy } = require('./groupByParser')
 const { parseLimit } = require('./limitParser')
 const SQLError = require('../models/SQLError')
+const { checkLimitPosition } = require('./parserTools/checkCorrectPosition')
 
 /**
  * Parses and validates a SELECT command object from the given string array.
@@ -74,6 +75,7 @@ const parseBaseCommand = (fullCommandAsStringArray) => {
     }
 
     if (queryContainsLimitKeyword(fullCommandAsStringArray)) {
+        checkLimitPosition(fullCommandAsStringArray)
         parsedCommand.limit = parseLimit(fullCommandAsStringArray)
         parsedCommand.indexOfLimit = fullCommandAsStringArray.findIndex(
             (s) => s.toUpperCase() === 'LIMIT'

--- a/commandParsers/selectParser.js
+++ b/commandParsers/selectParser.js
@@ -75,11 +75,11 @@ const parseBaseCommand = (fullCommandAsStringArray) => {
     }
 
     if (queryContainsLimitKeyword(fullCommandAsStringArray)) {
-        checkLimitPosition(fullCommandAsStringArray)
-        parsedCommand.limit = parseLimit(fullCommandAsStringArray)
-        parsedCommand.indexOfLimit = fullCommandAsStringArray.findIndex(
-            (s) => s.toUpperCase() === 'LIMIT'
+        const { limit, indexOfLimit } = handleLimitParsing(
+            fullCommandAsStringArray
         )
+        parsedCommand.limit = limit
+        parsedCommand.indexOfLimit = indexOfLimit
     } else if (
         fullCommandAsStringArray.some((s) => s.toUpperCase() === 'OFFSET')
     ) {
@@ -331,6 +331,29 @@ const parseSelectWhereGroupByOrderBy = (fullCommandAsStringArray) => {
     )
 
     return validatedCommand
+}
+
+/**
+ * Handles calling parseLimit with correct parameter and checks correct positioning
+ * of LIMIT and OFFSET.
+ * @param {object} parsedCommand parsed SELECT command object
+ * @param {string[]} fullCommandAsStringArray command as string array
+ */
+const handleLimitParsing = (fullCommandAsStringArray) => {
+    checkLimitPosition(fullCommandAsStringArray)
+
+    const indexOfLimit = fullCommandAsStringArray.findIndex(
+        (s) => s.toUpperCase() === 'LIMIT'
+    )
+
+    const limit = parseLimit(
+        fullCommandAsStringArray.slice(
+            indexOfLimit,
+            fullCommandAsStringArray.length - 1
+        )
+    )
+
+    return { limit, indexOfLimit }
 }
 
 module.exports = { parseCommand }

--- a/schemas/LimitSchema.js
+++ b/schemas/LimitSchema.js
@@ -25,11 +25,6 @@ const OffsetSchema = Joi.object({
  * Joi schema for validating LIMIT objects.
  */
 const LimitSchema = Joi.object({
-    correctlyPositioned: Joi.boolean().valid(true).required().messages({
-        'any.only':
-            'OFFSET must always be after LIMIT and LIMIT can not be before WHERE, GROUP BY or ORDER BY',
-    }),
-
     keyword: Joi.string()
         .pattern(/^LIMIT$/i)
         .required(),

--- a/tests/unit/limitParser.test.js
+++ b/tests/unit/limitParser.test.js
@@ -21,7 +21,6 @@ describe.each([
         test('is parsed and validated succesfully', () => {
             const parsedCommand = LimitSchema.validate(parseLimit(command))
 
-            expect(parsedCommand.value).toHaveProperty('correctlyPositioned')
             expect(parsedCommand.value).toHaveProperty('keyword')
             expect(parsedCommand.value).toHaveProperty('field')
             expect(parsedCommand.value).not.toHaveProperty('offset')
@@ -42,7 +41,6 @@ describe.each([
         test('is parsed and validated succesfully', () => {
             const parsedCommand = LimitSchema.validate(parseLimit(command))
 
-            expect(parsedCommand.value).toHaveProperty('correctlyPositioned')
             expect(parsedCommand.value).toHaveProperty('keyword')
             expect(parsedCommand.value).toHaveProperty('field')
             expect(parsedCommand.value).toHaveProperty('offset')
@@ -57,10 +55,6 @@ describe.each([
     'SELECT nimi, hinta FROM Tuotteet LIMIT column;',
     "SELECT nimi, hinta FROM Tuotteet LIMIT '24';",
     'SELECT nimi, hinta FROM Tuotteet LIMIT 2a+2;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 WHERE hinta=2;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 ORDER BY hinta;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 GROUP BY hinta;',
-    'SELECT nimi, hinta FROM Tuotteet OFFSET 2 LIMIT 2;',
     'SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET column;',
     "SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET '24';",
     'SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET 2a*2;',

--- a/tests/unit/limitParser.test.js
+++ b/tests/unit/limitParser.test.js
@@ -5,36 +5,34 @@ const {
 const { LimitSchema } = require('../../schemas/LimitSchema')
 const splitCommandIntoArray = require('../../commandParsers/parserTools/splitCommandIntoArray')
 
-describe.each([
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 20;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 + 2;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2*5+3;',
-])('Valid query containing LIMIT', (validCommand) => {
-    describe(validCommand, () => {
-        const command = splitCommandIntoArray(validCommand)
+describe.each(['LIMIT 2', 'LIMIT 20', 'LIMIT 2 + 2', 'LIMIT 2*5+3'])(
+    'Valid LIMIT part of a valid query',
+    (validCommand) => {
+        describe(validCommand, () => {
+            const command = splitCommandIntoArray(validCommand)
 
-        test('is recognised to contain a LIMIT keyword', () => {
-            expect(queryContainsLimitKeyword(command)).toBeTruthy()
+            test('is recognised to contain a LIMIT keyword', () => {
+                expect(queryContainsLimitKeyword(command)).toBeTruthy()
+            })
+
+            test('is parsed and validated succesfully', () => {
+                const parsedCommand = LimitSchema.validate(parseLimit(command))
+
+                expect(parsedCommand.value).toHaveProperty('keyword')
+                expect(parsedCommand.value).toHaveProperty('field')
+                expect(parsedCommand.value).not.toHaveProperty('offset')
+                expect(parsedCommand.error).toBeUndefined()
+            })
         })
-
-        test('is parsed and validated succesfully', () => {
-            const parsedCommand = LimitSchema.validate(parseLimit(command))
-
-            expect(parsedCommand.value).toHaveProperty('keyword')
-            expect(parsedCommand.value).toHaveProperty('field')
-            expect(parsedCommand.value).not.toHaveProperty('offset')
-            expect(parsedCommand.error).toBeUndefined()
-        })
-    })
-})
+    }
+)
 
 describe.each([
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET 2;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET 30;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET 2 + 2;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET 2*5+3;',
-])('Valid query containing LIMIT OFFSET', (validCommand) => {
+    'LIMIT 2 OFFSET 2',
+    'LIMIT 2 OFFSET 30',
+    'LIMIT 2 OFFSET 2 + 2',
+    'LIMIT 2 OFFSET 2*5+3',
+])('Valid LIMIT OFFSET part of a valid query', (validCommand) => {
     describe(validCommand, () => {
         const command = splitCommandIntoArray(validCommand)
 
@@ -52,13 +50,13 @@ describe.each([
 })
 
 describe.each([
-    'SELECT nimi, hinta FROM Tuotteet LIMIT column;',
-    "SELECT nimi, hinta FROM Tuotteet LIMIT '24';",
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2a+2;',
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET column;',
-    "SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET '24';",
-    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 OFFSET 2a*2;',
-])('Invalid query containing LIMIT or LIMIT OFFSET', (invalidCommand) => {
+    'LIMIT column',
+    "LIMIT '24'",
+    'LIMIT 2a+2',
+    'LIMIT 2 OFFSET column',
+    "LIMIT 2 OFFSET '24'",
+    'LIMIT 2 OFFSET 2a*2',
+])('Invalid LIMIT or LIMIT OFFSET part of a query', (invalidCommand) => {
     describe(invalidCommand, () => {
         const command = splitCommandIntoArray(invalidCommand)
 

--- a/tests/unit/selectAdvanced.test.js
+++ b/tests/unit/selectAdvanced.test.js
@@ -167,3 +167,22 @@ describe('Invalid SELECT query containing OFFSET without LIMIT', () => {
         )
     })
 })
+
+describe.each([
+    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 WHERE hinta=2;',
+    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 ORDER BY hinta;',
+    'SELECT nimi, hinta FROM Tuotteet LIMIT 2 GROUP BY hinta;',
+    'SELECT nimi, hinta FROM Tuotteet OFFSET 2 LIMIT 2;',
+])('Invalid query containing incorrectly placed LIMIT', (invalidCommand) => {
+    describe(invalidCommand, () => {
+        const command = splitCommandIntoArray(invalidCommand)
+
+        test('throws correct error during parsing', () => {
+            expect(() => selectParser.parseCommand(command)).toThrowError(
+                new SQLError(
+                    'OFFSET must always be after LIMIT and LIMIT can not be before WHERE, GROUP BY or ORDER BY'
+                )
+            )
+        })
+    })
+})


### PR DESCRIPTION
Refactored handling of LIMIT since the new error handling made it easier to handle things a bit differently.  Removed check for correct positioning of LIMIT from validation schema and to throw an error instead. This made it possible to change parseLimit() in limitParser to only take the limit part of  a query as parameter. Updated tests to match the new handling.