### PR TITLE
Bug fixes

### DIFF
--- a/commandParsers/whereParser.js
+++ b/commandParsers/whereParser.js
@@ -1,4 +1,5 @@
 const { parseConditions } = require('./fieldParser')
+const SQLError = require('../models/SQLError')
 
 /**
  * Parses the WHERE part of a command into a WHERE object from the given string array.
@@ -19,6 +20,13 @@ const parseWhere = (slicedCommandAsStringArray) => {
                     : slicedCommandAsStringArray.length
             )
         ),
+    }
+
+    if (
+        parsedWherePart.conditions.AND.length === 0 &&
+        parsedWherePart.conditions.OR.length === 0
+    ) {
+        throw new SQLError('WHERE clause must contain at least one condition')
     }
 
     return parsedWherePart

--- a/services/components/functions.js
+++ b/services/components/functions.js
@@ -16,12 +16,13 @@ const executeStringFunction = (functionFields, row) => {
     switch (functionFields.name) {
         case 'LENGTH':
             if (functionFields.param.type === 'column') {
-                if (!row[functionFields.param.value])
+                const columnValue = row[functionFields.param.value]
+                if (!columnValue && columnValue !== 0)
                     throw new SQLError(
                         'Column name given to LENGTH as parameter does not match any existing column'
                     )
 
-                return row[functionFields.param.value].toString().length
+                return columnValue.toString().length
             }
             return functionFields.param.value.toString().length
         case 'CONCAT':
@@ -61,7 +62,7 @@ const executeAggregateFunction = (functionFields, rows) => {
 
             const result = _.meanBy(rows, paramValue)
 
-            if (!result)
+            if (!result && result !== 0)
                 throw new SQLError(
                     'Parameter given to AVG does not match any existing column'
                 )
@@ -75,7 +76,7 @@ const executeAggregateFunction = (functionFields, rows) => {
         case 'MAX': {
             const result = _.get(_.maxBy(rows, paramValue), paramValue)
 
-            if (!result)
+            if (!result && result !== 0)
                 throw new SQLError(
                     'Parameter given to MAX does not match any existing column'
                 )
@@ -84,8 +85,7 @@ const executeAggregateFunction = (functionFields, rows) => {
         }
         case 'MIN': {
             const result = _.get(_.minBy(rows, paramValue), paramValue)
-
-            if (!result)
+            if (!result && result !== 0)
                 throw new SQLError(
                     'Parameter given to MIN does not match any existing column'
                 )
@@ -99,7 +99,7 @@ const executeAggregateFunction = (functionFields, rows) => {
 
             const result = _.sumBy(rows, paramValue)
 
-            if (!result)
+            if (!result && result !== 0)
                 throw new SQLError(
                     'Parameter given to SUM does not match any existing column'
                 )


### PR DESCRIPTION
Query containing a WHERE clause without any conditions now causes an error to be thrown. Also fixed MIN, MAX, SUM and AVG returning an error incorrectly when the result value was zero, instead of returning the expected 0. Corrected LENGTH to correctly handle 0 as a column value instead of throwing an incorrect error.